### PR TITLE
Fix clearnet anonymity guidance

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -482,9 +482,11 @@
                                 address and the address to which you're connecting. They *will not* be able to see which
                                 page you're on, who you're messaging, or the contents of your message.</p>
                             <p>When thinking about blowing the whistle, always consider: What are you protecting, and
-                                who are you protecting it from? Is it a message to the local newspaper about the noisy
-                                neighborhood construction, an abusive business owner, or a corrupt local official? You
-                                can connect using our clearnet address and have confidence you'll remain anonymous.</p>
+                                who are you protecting it from? For lower-risk situations, the clearnet address may be
+                                appropriate if you are not concerned about someone observing or later obtaining network
+                                logs that show you connected to Hush Line. If an employer, internet provider,
+                                government, or other adversary could use that metadata to identify you, use the Onion
+                                service with Tor and consider your broader operational security.</p>
                             <p>Or are you sharing national security secrets from within an authoritarian government that
                                 censors their internet and murders journalists? This is not legal advice, but a
                                 reasonable, though possibly prohibitively complex, way to ensure anonymity may be to


### PR DESCRIPTION
### Motivation
- Remove an overconfident statement that encouraged clearnet use with a guarantee of anonymity and instead restore guidance that ties advice to threat models and metadata risk.

### Description
- Replace the problematic paragraph in `src/index.html` with text clarifying that the clearnet address may be appropriate only for lower-risk situations and that the Onion service with Tor should be used when an employer, ISP, government, or other adversary could use connection metadata to identify a user.

### Testing
- Ran `rg -n "confidence you'll remain anonymous|abusive business owner|corrupt local official" src/index.html; test $? -eq 1` to verify the old phrasing was removed, and the command returned success. 
- Ran a minimal HTML parse with `python` using `HTMLParser` to ensure `src/index.html` remains parseable and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a06c530d1988325abc041c44da52a80)