### PR TITLE
Potential fix for code scanning alert no. 47: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mastodon.yml
+++ b/.github/workflows/mastodon.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [closed]
 
+permissions: {}
+
 jobs:
   post_to_mastodon:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
Potential fix for [https://github.com/scidsg/hushline-website/security/code-scanning/47](https://github.com/scidsg/hushline-website/security/code-scanning/47)

Add an explicit `permissions` block to the workflow (or job) with the minimum required scope.  
For this workflow, the safest non-breaking fix is to add a root-level block:

- `permissions: {}`

This sets all `GITHUB_TOKEN` permissions to none for all jobs unless overridden, which is appropriate here since the job does not use GitHub API writes and only posts to Mastodon via external token. This preserves existing functionality while ensuring least privilege.

**File to edit:** `.github/workflows/mastodon.yml`  
**Change location:** after the `on:` trigger block and before `jobs:`  
**No imports/dependencies/method additions needed.**


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
