### PR TITLE
Remove raw.githubusercontent.com from img-src CSP

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -25,7 +25,7 @@ server {
         object-src 'none';
         script-src 'self' 'unsafe-inline';
         style-src 'self' 'unsafe-inline';
-        img-src 'self' data: https://github.com https://avatars.githubusercontent.com https://raw.githubusercontent.com;
+        img-src 'self' data: https://github.com https://avatars.githubusercontent.com;
         font-src 'self';
         connect-src 'self' https://api.github.com;
         manifest-src 'self';


### PR DESCRIPTION
### Motivation
- The CSP allowed `https://raw.githubusercontent.com` in `img-src`, which would let browsers fetch onboarding screenshots from GitHub and leak visitor metadata to an external third party, so the policy should restrict images to site-hosted assets.

### Description
- Removed `https://raw.githubusercontent.com` from the `img-src` directive in `default.conf` so images are limited to `'self'`, `data:`, and the existing `https://github.com`/`https://avatars.githubusercontent.com` entries.

### Testing
- Executed a Python assertion script confirming `https://raw.githubusercontent.com` is absent from `default.conf` and the docs, verified the onboarding screenshot references the local path `/assets/img/screenshots/current/guest/guest-register-desktop-light-fold.png` and that the local image file exists, and ran `rg` to check for occurrences; all checks passed, while `nginx -t` could not be run because `nginx` is not installed in the container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08e5df22c48325953d1ffdbd891501)