### PR TITLE
Clarify conditional end-to-end encryption claims

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -64,7 +64,7 @@
             <div class="wrapper">
                 <div class="intro-copy">
                     <h2>
-                        Anonymous, end-to-end encrypted tip lines for journalists, lawyers, businesses, and more.
+                        Anonymous tip lines with end-to-end encryption when recipients add their public PGP key.
                     </h2>
                     <p>Hush Line is free and open-source whistleblower software that provides secure, anonymous, and accessible tip
                         lines with no self-hosting required.</p>
@@ -245,8 +245,8 @@
                 <div class="description">
                     <img src="assets/img/avatar-5.webp" alt="Software Makers Avatar">
                     <h3>Software Developers</h3>
-                    <p>How do you receive vulnerability reports for your software? End-to-end encrypted messages keep
-                        your secrets safe.</p>
+                    <p>How do you receive vulnerability reports for your software? Recipients can add their public
+                        PGP key to enable end-to-end encryption for sensitive messages.</p>
                 </div>
                 <div class="description">
                     <img src="assets/img/avatar-4-p.webp" alt="Activist Avatar">
@@ -378,8 +378,8 @@
                 <div class="wrapper">
                     <div class="description">
                         <div class="icon security"></div>
-                        <h3>End-to-End Encrypted</h3>
-                        <p>The same encryption trusted by scientists at CERN.</p>
+                        <h3>PGP-powered encryption</h3>
+                        <p>Add your public PGP key to enable end-to-end encryption with time-tested technology.</p>
                     </div>
                     <div class="description">
                         <div class="icon tor"></div>
@@ -429,7 +429,7 @@
                                     class="arrow" src="assets/img/icon-chevron.png" alt="chevron arrow"> Is
                                 Hush Line end-to-end encrypted?</button></h3>
                         <div class="faq-answer" id="faq2" hidden>
-                            <p>Yes! Hush Line uses <a href="https://github.com/openpgpjs/openpgpjs" target="_blank"
+                            <p>Yes, when a recipient adds their public PGP key. Hush Line uses <a href="https://github.com/openpgpjs/openpgpjs" target="_blank"
                                     rel="noopener noreferrer">OpenPGP.js</a> for client-side encryption, giving users
                                 who add their public PGP key end-to-end encryption for their messages. Users who disable
                                 JavaScript use server-side encryption.</p>
@@ -1127,8 +1127,8 @@
                         </div>
                         <div class="badge">
                             <img src="assets/img/badge-lock.png" alt="Tor Onion Service Badge">
-                            <p>E2EE</p>
-                            <p>End-to-End Encrypted</p>
+                            <p>PGP E2EE</p>
+                            <p>With Your PGP Key</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
### Motivation
- Remove an unconditional marketing claim that messages are end-to-end encrypted, which contradicted other site text stating E2EE is conditional on users adding a public PGP key and that non-JS/non-PGP flows use server-side or at-rest encryption.
- Avoid misleading users of a whistleblowing/tip-line product about confidentiality guarantees that depend on user configuration and client-side encryption.

### Description
- Update copy in `src/index.html` to qualify E2EE statements: change the hero line to clarify E2EE applies when recipients add their public PGP key.
- Replace audience-facing text (Software Developers) to explain recipients can add a public PGP key to enable E2EE rather than implying all messages are always E2EE.
- Change the privacy/security feature card header and paragraph to `PGP-powered encryption` and add a sentence that users must add their public PGP key to enable E2EE.
- Adjust the FAQ opening sentence and the footer badge wording to consistently state the PGP-conditioned nature of end-to-end encryption.

### Testing
- Ran `git diff --check` to verify no whitespace or diff issues and it passed. 
- Launched a local static server with `python -m http.server --directory src` and used a scripted `urllib` check to assert the updated qualified copy is present and the prior unconditional hero claim is absent, which succeeded. 
- Used targeted text searches (`rg`) to confirm all updated occurrences of unconditional E2EE wording were replaced, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08f911f6c88325a1d152e0ecd84ca7)