### PR TITLE
Avoid automatic third-party case study image requests

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -25,7 +25,7 @@ server {
         object-src 'none';
         script-src 'self' 'unsafe-inline';
         style-src 'self' 'unsafe-inline';
-        img-src 'self' data: https://github.com https://avatars.githubusercontent.com;
+        img-src 'self' data: https://avatars.githubusercontent.com;
         font-src 'self';
         connect-src 'self' https://api.github.com;
         manifest-src 'self';

--- a/src/case-study.html
+++ b/src/case-study.html
@@ -1073,9 +1073,12 @@
               `https://newassets.hcaptcha.com//captcha/v1/988e468/hcaptcha.js`
               along with multiple other javascript source files, and it executes
               them in the browser.” [31]</p>
-            <img
-              src="https://github.com/user-attachments/assets/a900e7cd-a0b5-413a-b8fe-ed1b25d8b909"
-              alt="Screenshot of hCaptcha assets loading in browser developer tools">
+            <p>
+              <a href="https://github.com/user-attachments/assets/a900e7cd-a0b5-413a-b8fe-ed1b25d8b909"
+                target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">
+                View screenshot of hCaptcha assets loading in browser developer tools
+              </a>.
+            </p>
 
             <h6>Local Captcha</h6>
             <p>We explored CAPTCHA options including creating an image with
@@ -1271,9 +1274,12 @@
                 USB, and Wifi on the device. A user boots it up, and an e-paper
                 display will show a QR code with the address to their Hush Line
                 Onion Service instance.</p>
-              <img
-                src="https://github.com/user-attachments/assets/2fc88bf0-9927-43cb-9422-f0e4dd7e5a98"
-                alt="Photo of the Hush Line Personal Server device">
+              <p>
+                <a href="https://github.com/user-attachments/assets/2fc88bf0-9927-43cb-9422-f0e4dd7e5a98"
+                  target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer">
+                  View photo of the Hush Line Personal Server device
+                </a>.
+              </p>
 
               <h4>System Requirements</h4>
               <p>The Personal Server is designed to be deployable to hardware


### PR DESCRIPTION
### Motivation
- The FAQ was changed to link to `case-study.html`, which contained embedded images hosted on `github.com/user-attachments`, causing automatic cross-origin image requests that can leak visitor metadata.
- The deployed Nginx config allowed `https://github.com` in the CSP `img-src` directive and did not prevent referrer leakage, so opening the page could expose sensitive visit information to a third party.

### Description
- Replace the two GitHub-hosted `<img>` embeds in `src/case-study.html` with explicit outbound links that use `target="_blank" rel="noopener noreferrer" referrerpolicy="no-referrer"` so images are not fetched automatically when the page loads.
- Update `default.conf` to remove `https://github.com` from the CSP `img-src` directive so GitHub-hosted images are not permitted by default.
- Preserve page content and layout while preventing automatic third-party requests; users can still view external images by following the explicit links.

### Testing
- Ran an HTML parse/assert script (`python3` snippet) that verified `src/case-study.html` contains zero external automatic `img` subresources and that the CSP `img-src` directive no longer includes `https://github.com`; the checks passed.
- Served the `src/` directory with `python3 -m http.server` and fetched `case-study.html` to confirm the modified page is served correctly; the fetch succeeded.
- Verified the CSP change with `rg`/text checks to ensure `https://github.com` was removed from the `img-src` directive; the check passed.
- Ran `git diff --check` to ensure no whitespace/errors in the working changes; the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08f9121bb0832584a00783c4ab9be4)