### PR TITLE
Fix route regex group backslash handling

### DIFF
--- a/src/library/assets/js/main.7b4b7676.js
+++ b/src/library/assets/js/main.7b4b7676.js
@@ -24879,7 +24879,7 @@ function escapeString (str) {
  * @return {string}
  */
 function escapeGroup (group) {
-  return group.replace(/([=!:$\/()\\])/g, '\\$1')
+  return group.replace(/([=!:$\/()])/g, '\\$1')
 }
 
 /**


### PR DESCRIPTION
### Motivation
- A recent change caused `escapeGroup()` to also escape backslashes, which double-escapes regex backslash sequences (e.g. `\d`) inside custom route capture groups and can break path-to-regexp style routes. 
- This is a latent functional regression that can cause developer-supplied custom regex groups to match literal backslashes instead of intended shorthands. 

### Description
- Removed backslash from the escape character class in `escapeGroup()` inside `src/library/assets/js/main.7b4b7676.js` so group content is no longer double-escaped. 
- The change is a single-line fix: `return group.replace(/([=!:$\/()\\])/g, '\\$1')` -> `return group.replace(/([=!:$\/()])/g, '\\$1')`, preserving regex shorthand like `\d` in capture groups. 
- This is a minimal behavior-preserving fix that restores correct custom-regex route matching without altering other escaping logic. 

### Testing
- Extracted the bundled `path-to-regexp` module (webpack module `5302`) with Node and verified that `/item/:id(\d+)` compiles to a regexp that matches `/item/123` and does not match `/item/\d`, and the test succeeded. 
- Ran `git diff --check` to ensure no whitespace/patch issues and confirmed the modified file contains the intended single-line change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a09082036c483259dc3c026e34c7543)