### PR TITLE
Fix legacy tab initialization for accessibility

### DIFF
--- a/src/assets/js/nav.js
+++ b/src/assets/js/nav.js
@@ -87,9 +87,17 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     const tabLinks = document.querySelectorAll('.tablinks');
-    tabLinks.forEach((tabLink, index) => {
-        const tabName = tabLink.dataset.tab;
+    const getTabName = tabLink => {
+        if (tabLink.dataset.tab) return tabLink.dataset.tab;
+        const onClick = tabLink.getAttribute('onclick') || '';
+        const match = onClick.match(/openTab\(event,\s*['"]([^'"]+)['"]\)/);
+        return match ? match[1] : null;
+    };
+
+    tabLinks.forEach(tabLink => {
+        const tabName = getTabName(tabLink);
         if (!tabName) return;
+
         tabLink.setAttribute("role", "tab");
         tabLink.setAttribute("aria-controls", tabName);
         tabLink.setAttribute("aria-selected", "false");
@@ -98,14 +106,16 @@ document.addEventListener('DOMContentLoaded', function() {
             tabLink.id = `tab-${tabName}`;
         }
 
-        tabLink.addEventListener("click", event => {
-            openTab(event, tabName);
-        });
+        if (tabLink.dataset.tab) {
+            tabLink.addEventListener("click", event => {
+                openTab(event, tabName);
+            });
+        }
 
         tabLink.addEventListener("keydown", event => {
             if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
             event.preventDefault();
-            const links = Array.from(tabLinks).filter(link => link.dataset.tab);
+            const links = Array.from(tabLinks).filter(link => getTabName(link));
             const currentIndex = links.indexOf(tabLink);
             let nextIndex = currentIndex;
 
@@ -128,8 +138,8 @@ document.addEventListener('DOMContentLoaded', function() {
         panel.setAttribute("aria-hidden", "true");
     });
 
-    const firstTab = document.querySelector('.tablinks[data-tab]');
+    const firstTab = Array.from(tabLinks).find(link => getTabName(link));
     if (firstTab) {
-        openTab({ currentTarget: firstTab }, firstTab.dataset.tab);
+        openTab({ currentTarget: firstTab }, getTabName(firstTab));
     }
 });


### PR DESCRIPTION
### Motivation
- A recent change only initialized tab buttons that use `data-tab`, leaving legacy `.tablinks` that rely on inline `onclick="openTab(...)"` uninitialized and their corresponding `.tabcontent` panels marked `aria-hidden="true"`, which hid visible onboarding content from assistive technology.

### Description
- Add a small `getTabName()` helper that resolves a tab target from either `data-tab` or by parsing an inline `onclick="openTab(event, 'Name')"` handler.
- Apply ARIA roles/attributes to all `.tablinks` and `.tabcontent` elements and update keyboard-navigation filtering to use `getTabName()` so legacy tabs participate in keyboard focus order.
- Only bind the programmatic `click` handler when `data-tab` is present to preserve existing behavior for modern tabs and avoid duplicating inline handlers.
- Select the first available tab by using `getTabName()` and call `openTab()` with the resolved name so a tabpanel is exposed to assistive tech on load.

### Testing
- Ran `node --check src/assets/js/nav.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a16bd7a8cd883259d3caa190d5c1483)