### PR TITLE
Fix funding manifest wellKnown URL to raw GitHub endpoint

### DIFF
--- a/src/.well-known/funding.json
+++ b/src/.well-known/funding.json
@@ -22,7 +22,7 @@
       },
       "repositoryUrl": {
         "url": "https://github.com/scidsg/hushline",
-        "wellKnown": "https://github.com/scidsg/hushline/blob/main/.well-known/funding-manifest-urls"
+        "wellKnown": "https://raw.githubusercontent.com/scidsg/hushline/main/.well-known/funding-manifest-urls"
       },
       "licenses": ["spdx:AGPL-3.0"],
       "tags": ["whistleblowing", "security", "privacy", "foss", "journalism"]


### PR DESCRIPTION
### Motivation
- The `projects[0].repositoryUrl.wellKnown` field in `src/.well-known/funding.json` was changed to a GitHub `/blob/` web UI URL which serves HTML instead of the raw `funding-manifest-urls` document, breaking automated funding metadata discovery. 

### Description
- Replaced the `/blob/` URL with the corresponding `raw.githubusercontent.com` endpoint in `src/.well-known/funding.json` so automated consumers can fetch the machine-readable manifest. 

### Testing
- Ran `git diff -- src/.well-known/funding.json` to verify the change and `python -m json.tool src/.well-known/funding.json` to validate JSON syntax, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a16bd7bd3a083259ef7b04b93c072a3)