### PR TITLE
Fix malformed HTML in case-study 'Path to Launch' section

### DIFF
--- a/src/case-study.html
+++ b/src/case-study.html
@@ -1577,7 +1577,7 @@
                   username, password, port, and server. A query at the end of
                   the beta period showed that only 1.35% of participants
                   configured message forwarding.</p>
-                <p><b>Beta Numbers</b></h4>
+                <p><b>Beta Numbers</b></p>
                   <p>Enrollment numbers for features like two-factor
                     authentication appear low but are actually consistent with
                     what we see with major platforms like Twitter, where the 2FA
@@ -1739,9 +1739,9 @@
                       <li>$100,000</li>
                     </ul>
                     <li>Describe what activities you would use the grant to
-                      undertake.</li>
-                    <ul>
-                      <li>As we prepare for launch, we must consider
+                      undertake.
+                      <ul>
+                        <li>As we prepare for launch, we must consider
                         infrastructure needs for scaling our service and,
                         perhaps most importantly, mitigations for DOS attacks
                         since we’ll have journalists and other at-risk groups as
@@ -1760,12 +1760,13 @@
                             RUST.</li>
                         </ul>
                       </ul>
+                    </li>
                       <li>Describe what outputs you would use the grant to
                         produce. These are the things your activities will
-                        produce.</li>
-                      <ul>
-                        <li>The output of our activities will come with
-                          significant benefits to our product, including:</li>
+                        produce.
+                        <ul>
+                          <li>The output of our activities will come with
+                            significant benefits to our product, including:
                         <ul>
                           <li>More resilient infrastructure to attack.</li>
                           <li>More reliable service for users experiencing
@@ -1782,7 +1783,9 @@
                           <li>New features tailored for expanded organizational
                             needs.</li>
                         </ul>
-                      </ul>
+                          </li>
+                        </ul>
+                      </li>
                       <li>Describe what outcomes you would use the grant to
                         achieve.</li>
                       <ul>


### PR DESCRIPTION
### Motivation
- Correct malformed static HTML introduced in the "Path to Launch" / beta/grant sections of `src/case-study.html` that caused an incorrect closing tag and invalid nested list structure which can trigger browser DOM repair and accessibility/styling issues.
- This is a correctness/markup fix with no security behavior changes and it preserves the original textual content and intent of the page.

### Description
- Replace the stray `</h4>` closing tag with a proper `</p>` for the "Beta Numbers" paragraph in `src/case-study.html` to fix the mismatched element closure.
- Restructure the grant Q&A nested lists by moving child `<ul>` blocks inside their parent `<li>` elements and balancing the corresponding closing tags so list nesting is valid and semantic.
- Only `src/case-study.html` was modified and no page content text was changed beyond markup reorganization.

### Testing
- Ran `sed -n '1540,1795p' src/case-study.html` to inspect the affected region and confirm the corrected markup appears in context (succeeded).
- Used `rg -n` to locate the previously problematic lines and verified they no longer contain the malformed tokens (succeeded).
- Verified the diff with `git diff -- src/case-study.html` and committed the change with `git commit -m "Fix malformed HTML in case study launch section"` to ensure only the intended edits were introduced (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a16b9740f9c8325b99dd91f71c10c05)