### PR TITLE
Pin library artifact workflow checkout action

### DIFF
--- a/.github/workflows/check-library-conflicts.yml
+++ b/.github/workflows/check-library-conflicts.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Reject conflict markers in published library
         run: |


### PR DESCRIPTION
## What changed

- Pins `actions/checkout` in the library artifact conflict-marker workflow to the full commit SHA behind `v4`.

## Why

The workflow failed on `main` because repository policy requires third-party GitHub Actions to be pinned to a full-length commit SHA. The job failed during setup before it could run the artifact scan.

## Validation

- `git diff --check`
- `git grep -n -E '<<<<<<<|>>>>>>>|Updated upstream|Stashed changes' -- src/library` returned no matches

## Manual testing

Not applicable. This is a workflow metadata-only fix for Actions policy compliance.

## Risks / follow-ups

- The pinned checkout SHA should be reviewed when upgrading checkout in the future.