### PR TITLE
Fix invalid website links

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -675,7 +675,7 @@
                                 can I submit a vulnerability report?</button></h3>
                         <div class="faq-answer" id="faq12" hidden>
                             <p>See something, say something! Submit a vulnerability report if you find a security issue,
-                                and we'll address it immediately! <a href="https://tips.hushline.app/to/scidsg"
+                                and we'll address it immediately! <a href="https://tips.hushline.app/to/admin"
                                     target="_blank" rel="noopener noreferrer">Submit a report!</a></p>
                         </div>
                     </li>

--- a/src/start-here.html
+++ b/src/start-here.html
@@ -161,7 +161,7 @@
                     <section class="congrats">
                         <div class="wrapper">
                             <h3>🎉<br>Congratulations!</h3>
-                            <p>Now that you're set up, you can share your tip line with your organization or community. If you have any questions, feel free to reach out to us <a href="https://tips.hushline.app/to/scidsg" target="_blank" rel="noopener noreferrer">using our Hush Line account.</a></p>
+                            <p>Now that you're set up, you can share your tip line with your organization or community. If you have any questions, feel free to reach out to us <a href="https://tips.hushline.app/to/admin" target="_blank" rel="noopener noreferrer">using our Hush Line account.</a></p>
                         </div>
                     </section>
                 </div>

--- a/src/team.html
+++ b/src/team.html
@@ -44,10 +44,10 @@
                 <li><a href="team.html">Team</a></li>
                 <li><a href="/library/docs/getting-started/start-here">Docs</a></li>
                 <li><a href="/library/blog/" rel="noopener noreferrer">Blog</a></li>
-                <li><a href="#pricing">Pricing</a></li>
-                <li><a href="#faq">FAQ</a></li>
+                <li><a href="index.html#pricing">Pricing</a></li>
+                <li><a href="index.html#faq">FAQ</a></li>
                 <li><a href="https://shop.scidsg.org/collections/hush-line" rel="noopener noreferrer" target="_blank">Shop</a></li>
-                <li><span class="btn-emoji">❤️</span><a class="btn" href="https://opencollective.com/scidsg/contribute/hush-line-supporter-55786"
+                <li><span class="btn-emoji">❤️</span><a class="btn" href="https://opencollective.com/hushline/contribute/hush-line-supporter-55786"
                         target="_blank" rel="noopener noreferrer">Donate</a></li>
             </ul>
             <a class="btn primaryBtn" href="https://tips.hushline.app/login" target="_blank"
@@ -70,7 +70,7 @@
                 </p>
                 <div class="btnContainer">
                     <a href="https://tips.hushline.app/register" class="btn btnLrg primaryBtn" rel="noopener noreferrer" target="_blank">Create Your Tip Line</a>
-                    <a href="https://opencollective.com/scidsg/contribute/hush-line-supporter-55786" class="btn btnLrg" rel="noopener noreferrer" target="_blank"><span class="btn-emoji">❤️</span> Donate</a>
+                    <a href="https://opencollective.com/hushline/contribute/hush-line-supporter-55786" class="btn btnLrg" rel="noopener noreferrer" target="_blank"><span class="btn-emoji">❤️</span> Donate</a>
                 </div>
             </div>
         </section>

--- a/src/test.html
+++ b/src/test.html
@@ -156,7 +156,7 @@
                     <section class="congrats">
                         <div class="wrapper">
                             <h3>🎉<br>Congratulations!</h3>
-                            <p>Now that you're set up, you can share your tip line with your organization or community. If you have any questions, feel free to reach out to us <a href="https://tips.hushline.app/to/scidsg" target="_blank" rel="noopener noreferrer">using our Hush Line account.</a></p>
+                            <p>Now that you're set up, you can share your tip line with your organization or community. If you have any questions, feel free to reach out to us <a href="https://tips.hushline.app/to/admin" target="_blank" rel="noopener noreferrer">using our Hush Line account.</a></p>
                         </div>
                     </section>
                 </div>
@@ -241,7 +241,7 @@
                                 <div class="description">
                                     <p class="step-label">Step 2.</p>
                                     <h3>Verify a URL</h3>
-                                    <p>Optionally, for expedited account verification, you can add an auto-verifying URL to your profile. Auto-verifying URLs provide evidence of ownership or a relationship to an external address. For example, Science & Design added a link on our public website, scidsg.org, pointing to our Hush Line profile. The link code looks like this: &lt;a href=&quot;https://tips.hushline.app/to/scidsg&quot; rel=&quot;me&quot;&gt;Hush Line&lt;/a&gt;. In the Extra Fields fieldset, we've added the address of our site containing our Hush Line information: https://scidsg.org. When we click Update Bio, we'll check that site for your Hush Line address and automatically verify the URL. </p>
+                                    <p>Optionally, for expedited account verification, you can add an auto-verifying URL to your profile. Auto-verifying URLs provide evidence of ownership or a relationship to an external address. For example, Science & Design added a link on our public website, scidsg.org, pointing to our Hush Line profile. The link code looks like this: &lt;a href=&quot;https://tips.hushline.app/to/admin&quot; rel=&quot;me&quot;&gt;Hush Line&lt;/a&gt;. In the Extra Fields fieldset, we've added the address of our site containing our Hush Line information: https://scidsg.org. When we click Update Bio, we'll check that site for your Hush Line address and automatically verify the URL. </p>
                                 </div>
                                 <img src="assets/img/docs/verifiy-url.webp" alt="Wireframe of the Authentication tab in Settings with an arrow pointing to the extra fields heading.">
                             </div>


### PR DESCRIPTION
## Summary

- Fixed the broken Hush Line report/profile links by pointing them at the valid `admin` account.
- Updated Team page Pricing and FAQ nav links to target the landing page sections instead of missing same-page anchors.
- Updated Team page donation links to the current Hush Line OpenCollective contribution URL.

Closes #43

## Validation

- `git diff --check`
- `rg -n "opencollective\\.com/scidsg/contribute/hush-line-supporter-55786|tips\\.hushline\\.app/to/scidsg" src`
- `rg -n "href=\\\"#pricing\\\"|href=\\\"#faq\\\"" src/team.html`
- Local static fragment-target validation for internal hash links
- `curl -I https://tips.hushline.app/to/admin`
- `curl -I https://opencollective.com/hushline/contribute/hush-line-supporter-55786`
- `docker build -t hushline-website-linkfix .`

## Manual Testing

- Static link checks confirm the old invalid URLs are removed and the replacement URLs return HTTP 200.
