### PR TITLE
Fix CodeQL regex escaping alert

### DIFF
--- a/src/library/assets/js/main.b4c395ea.js
+++ b/src/library/assets/js/main.b4c395ea.js
@@ -24879,7 +24879,7 @@ function escapeString (str) {
  * @return {string}
  */
 function escapeGroup (group) {
-  return group.replace(/([=!:$\/()])/g, '\\$1')
+  return group.replace(/([=!:$\/()\\])/g, '\\$1')
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes CodeQL alert 63 (`js/incomplete-sanitization`) by escaping existing backslashes in the bundled regex group escaping helper.
- Keeps the existing global replacement behavior and only expands the escaped metacharacter set.

Code scanning alert: https://github.com/scidsg/hushline-website/security/code-scanning/63

## Validation

- `git diff --check`
- `node -e 'const escapeGroup = (group) => group.replace(/([=!:$\\/()\\\\])/g, "\\\\$1"); const input = "a\\\\b(c):d=e/f!$"; const actual = escapeGroup(input); const expected = "a\\\\\\\\b\\\\(c\\\\)\\\\:d\\\\=e\\\\/f\\\\!\\\\$"; if (actual !== expected) { console.error({actual, expected}); process.exit(1); } console.log(actual);'`
- `docker build -t hushline-website-code-scanning-63 .`

## Manual Testing

- Not applicable; this is a static bundled helper patch for a CodeQL finding.
