### PR TITLE
Hide nginx version on 404 pages

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -1,6 +1,7 @@
 server {
     listen 80;
     server_name localhost;
+    server_tokens off;
 
     root /usr/share/nginx/html;
     index index.html index.htm;
@@ -35,6 +36,9 @@ server {
     location / {
         try_files $uri $uri/ =404;
     }
+
+    error_page 404 /404.html;
+    location = /404.html { internal; }
 
     error_page 500 502 503 504 /50x.html;
     location = /50x.html { root /usr/share/nginx/html; }

--- a/src/404.html
+++ b/src/404.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="description" content="The requested Hush Line page could not be found.">
+    <meta name="author" content="Hush Line">
+    <meta name="theme-color" content="#7D25C1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex">
+    <title>Page Not Found | Hush Line</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/img/favicon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" href="/assets/img/favicon/favicon-16x16.png" sizes="16x16">
+    <link rel="icon" type="image/png" href="/assets/img/favicon/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/assets/img/favicon/android-chrome-192x192.png" sizes="192x192">
+    <link rel="icon" type="image/png" href="/assets/img/favicon/android-chrome-512x512.png" sizes="512x512">
+    <link rel="icon" type="image/x-icon" href="/assets/img/favicon/favicon.ico">
+    <link rel="stylesheet" href="/assets/css/reset.css">
+    <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+
+<body class="landing not-found">
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <header class="island">
+        <h1><a href="/">🤫 Hush Line</a></h1>
+        <nav>
+            <button type="button" class="mobileNav btnIcon" aria-label="Navigation menu">Menu</button>
+            <ul>
+                <li><a href="https://tips.hushline.app/directory">Directory</a></li>
+                <li><a href="/team.html">Team</a></li>
+                <li><a href="/library/docs/getting-started/start-here">Docs</a></li>
+                <li><a href="/library/blog/" rel="noopener noreferrer">Blog</a></li>
+                <li><a href="/index.html#pricing">Pricing</a></li>
+                <li><a href="/index.html#faq">FAQ</a></li>
+                <li><a href="https://shop.scidsg.org/collections/hush-line" rel="noopener noreferrer" target="_blank">Shop</a></li>
+                <li><span class="btn-emoji">❤️</span><a class="btn" href="https://opencollective.com/hushline/contribute/hush-line-supporter-55786"
+                        target="_blank" rel="noopener noreferrer">Donate</a></li>
+            </ul>
+            <a class="btn primaryBtn" href="https://tips.hushline.app/login" target="_blank"
+                rel="noopener noreferrer">Login</a>
+        </nav>
+    </header>
+
+    <main class="landing" id="main-content" tabindex="-1">
+        <section class="intro secondary">
+            <div class="wrapper">
+                <h2>Page not found</h2>
+                <p>The page you requested does not exist or has moved.</p>
+                <div class="btnContainer">
+                    <a class="btn btnLrg primaryBtn" href="/">Go home</a>
+                    <a class="btn btnLrg" href="/library/docs/getting-started/start-here">Read the docs</a>
+                </div>
+            </div>
+        </section>
+    </main>
+    <script src="/assets/js/nav.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary

- Disables nginx `server_tokens` for the website container.
- Adds a root-level custom `404.html` page so missing static paths no longer render nginx's default 404 body.
- Configures nginx to serve the custom 404 page internally for 404 responses.

Closes #24

## Validation

- `git diff --check`
- `docker build -t hushline-website-issue-24 .`
- `docker run --rm hushline-website-issue-24 nginx -t`
- `curl -I http://127.0.0.1:8095/this-page-does-not-exist`

## Manual Testing

- Ran the built nginx container locally and requested a missing page.
- Confirmed the response status is `404 Not Found`.
- Confirmed the `Server` header is `nginx` without an exposed version number.
- Confirmed the response content length matches the custom `src/404.html` page.
