### PR TITLE
Temporarily disable broken admin embed

### DIFF
--- a/src/embed.html
+++ b/src/embed.html
@@ -42,7 +42,8 @@
                     <p>Thank you for stopping by! Hush Line is a 501(c)(3) non-profit in the US. Get in touch using one
                         of the channels
                         below! </p>
-                <iframe src="https://tips.hushline.app/embed/to/admin" title="Send a secure Hush Line message to Hush Line Admin" sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-scripts allow-top-navigation-by-user-activation" referrerpolicy="no-referrer" width="100%" height="1300" style="width:100%;max-width:720px;height:1300px;border:0;outline:1px solid rgba(0,0,0,0.18);border-radius:0.25rem;box-shadow:0px 4px 8px -4px rgba(0,0,0,0.15);"></iframe><script>(function(){var iframe=document.currentScript&&document.currentScript.previousElementSibling;if(!iframe||iframe.tagName!=="IFRAME")return;var origin;try{origin=new URL(iframe.src).origin;}catch(error){return;}window.addEventListener("message",function(event){if(event.source!==iframe.contentWindow)return;if(event.origin!==origin&&event.origin!=="null")return;var data=event.data||{};if(data.type!=="hushline:embed:height"||data.version!==1)return;var height=Number(data.height);if(!Number.isInteger(height)||height<320||height>4096)return;iframe.height=String(height);iframe.style.height=height+"px";});})();</script>                </div>
+                <!-- Embedded Hush Line contact form temporarily disabled while origin validation is repaired. -->
+                </div>
             </div>
         </section>
     </main>


### PR DESCRIPTION
### Motivation
- The embedded admin contact form is currently failing submissions with `Invalid embed request origin`.
- Until the embed origin behavior is verified end to end, the website should not show a broken embedded form to visitors.

### Description
- Temporarily remove the active admin iframe from `src/embed.html`.
- Leave a marker comment so we can restore the embed after the Hush Line app/browser-origin behavior is confirmed.
- Keep the already-commented homepage iframe on `main` unchanged.

### Validation
- `git diff --check` passed.
- Confirmed the PR no longer contains an active iframe in `src/embed.html`.

### Manual Testing
- After deploy, load the standalone contact page and confirm it no longer displays the broken embedded form or `Invalid embed request origin` error.

### Follow-up
- Re-add the iframe only after validating a working embed submission path in browser against production-like origins.